### PR TITLE
Fix/idp persistent name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN curl -s -L -o /tmp/simplesamlphp.tar.gz https://github.com/simplesamlphp/sim
     mv /tmp/simplesamlphp-* /app/public/simplesamlphp && \
     touch /app/public/simplesamlphp/modules/exampleauth/enable
 
-COPY config/simplesamlphp/config.php /app/public/simplesamlphp/config
+COPY config/simplesamlphp/config.php /app/public/simplesamlphp/config/
+COPY config/simplesamlphp/saml20-idp-hosted.php /app/public/simplesaml/metadata/
 COPY config/simplesamlphp/server.crt /app/public/simplesamlphp/cert/
 COPY config/simplesamlphp/server.pem /app/public/simplesamlphp/cert/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN curl -s -L -o /tmp/simplesamlphp.tar.gz https://github.com/simplesamlphp/sim
     touch /app/public/simplesamlphp/modules/exampleauth/enable
 
 COPY config/simplesamlphp/config.php /app/public/simplesamlphp/config/
-COPY config/simplesamlphp/saml20-idp-hosted.php /app/public/simplesaml/metadata/
+COPY config/simplesamlphp/saml20-idp-hosted.php /app/public/simplesamlphp/metadata/
 COPY config/simplesamlphp/server.crt /app/public/simplesamlphp/cert/
 COPY config/simplesamlphp/server.pem /app/public/simplesamlphp/cert/
 

--- a/config/simplesamlphp/saml20-idp-hosted.php
+++ b/config/simplesamlphp/saml20-idp-hosted.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * SAML 2.0 IdP configuration for SimpleSAMLphp.
+ *
+ * See: https://simplesamlphp.org/docs/stable/simplesamlphp-reference-idp-hosted
+ */
+
+$metadata['__DYNAMIC:1__'] = [
+    /*
+     * The hostname of the server (VHOST) that will use this SAML entity.
+     *
+     * Can be '__DEFAULT__', to use this entry by default.
+     */
+    'host' => '__DEFAULT__',
+
+    // X.509 key and certificate. Relative to the cert directory.
+    'privatekey' => 'server.pem',
+    'certificate' => 'server.crt',
+
+    /*
+     * Authentication source to use. Must be one that is configured in
+     * 'config/authsources.php'.
+     */
+    'auth' => 'example-userpass',
+    'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+    'authproc' => array(
+        3 => array(
+            'class' => 'saml:AttributeNameID',
+            'attribute' => 'email',
+            'Format' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress',
+        ),
+    ),
+];


### PR DESCRIPTION
this PR will fix the issue where a certain service provider receives every time a new hashed value for each login. Instead, I want them to see a persistent name ID in form of an email address. (Which is in most cases the most unique thing you can get, disregarding other non-default attributes)